### PR TITLE
fix studio will crash if editor_camera'slot been changed

### DIFF
--- a/src/editor/editor_icon.cpp
+++ b/src/editor/editor_icon.cpp
@@ -140,8 +140,9 @@ void EditorIcon::render(PipelineInstance& pipeline)
 	static const float MAX_SCALE_FACTOR = 60;
 	if (m_is_visible)
 	{
-		const Universe& universe = m_scene->getUniverse();
 		ComponentIndex camera = m_scene->getCameraInSlot("editor");
+		if (camera < 0) return;
+		const Universe& universe = m_scene->getUniverse();
 		Lumix::Matrix mtx = universe.getMatrix(m_scene->getCameraEntity(camera));
 
 		float fov = m_scene->getCameraFOV(camera);

--- a/src/renderer/pipeline.cpp
+++ b/src/renderer/pipeline.cpp
@@ -849,6 +849,8 @@ struct PipelineInstanceImpl : public PipelineInstance
 									int framebuffers_count,
 									int64 layer_mask)
 	{
+		if (camera < 0) return;
+
 		Universe& universe = m_scene->getUniverse();
 		Entity camera_entity = m_scene->getCameraEntity(camera);
 		Vec3 camera_pos = universe.getPosition(camera_entity);


### PR DESCRIPTION
How to reproduce the bug:

1. Open any scene, select "editor_camera" entity
2. Change slot from "editor" to anything else
3. Studio will crash

Fixed by adding more valid camera index check.

