### PR TITLE
Make array more memory safe

### DIFF
--- a/src/editor/studio_app.cpp
+++ b/src/editor/studio_app.cpp
@@ -34,6 +34,7 @@
 #include "settings.h"
 #include "studio_app.h"
 #include "utils.h"
+#include <array>
 
 
 class StudioAppImpl* g_app;
@@ -1253,7 +1254,7 @@ public:
 		Lumix::uint64 offset;
 		Lumix::uint64 size;
 
-		typedef char Path[Lumix::MAX_PATH_LENGTH];
+		using Path = std::array<char, Lumix::MAX_PATH_LENGTH>;
 	};
 	#pragma pack()
 
@@ -1283,16 +1284,16 @@ public:
 			auto& out_path = paths.emplace();
 			if(dir_path[0] == '.')
 			{
-				Lumix::copyString(out_path, Lumix::lengthOf(out_path), normalized_path);
+				Lumix::copyString(out_path.data(), out_path.size(), normalized_path);
 			}
 			else
 			{
-				Lumix::copyString(out_path, Lumix::lengthOf(out_path), dir_path);
-				Lumix::catString(out_path, Lumix::lengthOf(out_path), normalized_path);
+				Lumix::copyString(out_path.data(), out_path.size(), dir_path);
+				Lumix::catString(out_path.data(), out_path.size(), normalized_path);
 			}
 			auto& out_info = infos.emplace();
-			out_info.hash = Lumix::crc32(out_path);
-			out_info.size = PlatformInterface::getFileSize(out_path);
+			out_info.hash = Lumix::crc32(out_path.data());
+			out_info.size = PlatformInterface::getFileSize(out_path.data());
 			out_info.offset = ~0UL;
 		}
 	}
@@ -1339,11 +1340,11 @@ public:
 		for (auto& path : paths)
 		{
 			Lumix::FS::OsFile src;
-			size_t src_size = PlatformInterface::getFileSize(path);
-			if (!src.open(path, Lumix::FS::Mode::OPEN_AND_READ, m_allocator))
+			size_t src_size = PlatformInterface::getFileSize(path.data());
+			if (!src.open(path.data(), Lumix::FS::Mode::OPEN_AND_READ, m_allocator))
 			{
 				file.close();
-				Lumix::g_log_error.log("Editor") << "Could not open " << path;
+				Lumix::g_log_error.log("Editor") << "Could not open " << path.data();
 				return;
 			}
 			Lumix::uint8 buf[4096];
@@ -1353,7 +1354,7 @@ public:
 				if (!src.read(buf, batch_size))
 				{
 					file.close();
-					Lumix::g_log_error.log("Editor") << "Could not read " << path;
+					Lumix::g_log_error.log("Editor") << "Could not read " << path.data();
 					return;
 				}
 				file.write(buf, batch_size);

--- a/src/engine/core/array.h
+++ b/src/engine/core/array.h
@@ -7,7 +7,7 @@
 namespace Lumix
 {
 
-template <class T> inline void swap(T &lhs, T &rhs)
+template <class T> inline void myswap(T &lhs, T &rhs)
 {
 	T tmp = mymove(lhs);
 	lhs = mymove(rhs);
@@ -25,7 +25,7 @@ public:
 		m_size = 0;
 	}
 
-	explicit Array(const Array& rhs)
+	Array(const Array& rhs)
 		: m_allocator(rhs.m_allocator)
 	{
 		m_data = nullptr;
@@ -34,7 +34,7 @@ public:
 		*this = rhs;
 	}
 
-	explicit Array(Array&& rhs)
+	Array(Array&& rhs)
 		: m_allocator(rhs.m_allocator)
 	{
 		m_data = rhs.m_data;
@@ -57,11 +57,11 @@ public:
 	{
 		ASSERT(&rhs.m_allocator == &m_allocator);
 
-		using Lumix::swap;
+		using Lumix::myswap;
 
-		swap(rhs.m_capacity, m_capacity);
-		swap(rhs.m_size, m_size);
-		swap(rhs.m_data, m_data);
+		myswap(rhs.m_capacity, m_capacity);
+		myswap(rhs.m_size, m_size);
+		myswap(rhs.m_data, m_data);
 	}
 
 
@@ -146,8 +146,8 @@ public:
 		{
 			if (index != m_size - 1)
 			{
-				using Lumix::swap;
-				swap(m_data[index], m_data[m_size - 1]);
+				using Lumix::myswap;
+				myswap(m_data[index], m_data[m_size - 1]);
 			}
 			m_data[m_size - 1].~T();
 			--m_size;

--- a/src/engine/core/array.h
+++ b/src/engine/core/array.h
@@ -2,11 +2,17 @@
 
 
 #include "engine/core/iallocator.h"
-
+#include "engine/core/type_traits.h"
 
 namespace Lumix
 {
 
+template <class T> inline void swap(T &lhs, T &rhs)
+{
+	T tmp = mymove(lhs);
+	lhs = mymove(rhs);
+	rhs = mymove(tmp);
+}
 
 template <typename T> class Array
 {
@@ -28,6 +34,18 @@ public:
 		*this = rhs;
 	}
 
+	explicit Array(Array&& rhs)
+		: m_allocator(rhs.m_allocator)
+	{
+		m_data = rhs.m_data;
+		m_capacity = rhs.m_capacity;
+		m_size = rhs.m_size;
+
+		rhs.m_data = nullptr;
+		rhs.m_capacity = 0;
+		rhs.m_size = 0;
+	}
+
 
 	T* begin() const { return m_data; }
 
@@ -39,17 +57,11 @@ public:
 	{
 		ASSERT(&rhs.m_allocator == &m_allocator);
 
-		int i = rhs.m_capacity;
-		rhs.m_capacity = m_capacity;
-		m_capacity = i;
+		using Lumix::swap;
 
-		i = m_size;
-		m_size = rhs.m_size;
-		rhs.m_size = i;
-
-		T* p = rhs.m_data;
-		rhs.m_data = m_data;
-		m_data = p;
+		swap(rhs.m_capacity, m_capacity);
+		swap(rhs.m_size, m_size);
+		swap(rhs.m_data, m_data);
 	}
 
 
@@ -73,15 +85,15 @@ public:
 	{
 		if (this != &rhs)
 		{
-			callDestructors(m_data, m_data + m_size);
-			m_allocator.deallocate(m_data);
-			m_data = (T*)m_allocator.allocate(rhs.m_capacity * sizeof(T));
-			m_capacity = rhs.m_capacity;
-			m_size = rhs.m_size;
-			for (int i = 0; i < m_size; ++i)
-			{
-				new (Lumix::NewPlaceholder(), (char*)(m_data + i)) T(rhs.m_data[i]);
-			}
+			Array(rhs).swap(*this);
+		}
+	}
+
+	void operator=(Array&& rhs)
+	{
+		if (this != &rhs)
+		{
+			Array(mymove(rhs)).swap(*this);
 		}
 	}
 
@@ -132,11 +144,12 @@ public:
 	{
 		if (index >= 0 && index < m_size)
 		{
-			m_data[index].~T();
 			if (index != m_size - 1)
 			{
-				moveMemory(m_data + index, m_data + m_size - 1, sizeof(T));
+				using Lumix::swap;
+				swap(m_data[index], m_data[m_size - 1]);
 			}
+			m_data[m_size - 1].~T();
 			--m_size;
 		}
 	}
@@ -156,69 +169,48 @@ public:
 
 	void insert(int index, const T& value)
 	{
-		if (m_size == m_capacity)
+		if (index == m_size)
 		{
-			grow();
+			push(value);
+			return;
 		}
-		moveMemory(m_data + index + 1, m_data + index, sizeof(T) * (m_size - index));
-		new (NewPlaceholder(), &m_data[index]) T(value);
-		++m_size;
+		makePlaceAt(index);
+		m_data[index] = value;
 	}
 
 
 	void erase(int index)
 	{
-		if (index >= 0 && index < m_size)
+		if (index < 0 && index >= m_size)
 		{
-			m_data[index].~T();
-			if (index < m_size - 1)
-			{
-				moveMemory(m_data + index, m_data + index + 1, sizeof(T) * (m_size - index - 1));
-			}
-			--m_size;
+			return;
 		}
+
+		for (int i = index; i < m_size - 1; ++i)
+		{
+			m_data[i] = mymove(m_data[i + 1]);
+		}
+		m_data[m_size - 1].~T();
+		--m_size;
 	}
 
 	void push(const T& value)
 	{
-		int size = m_size;
-		if (size == m_capacity)
-		{
-			grow();
-		}
-		new (NewPlaceholder(), (char*)(m_data + size)) T(value);
-		++size;
-		m_size = size;
+		ensureCapacity();
+		new (NewPlaceholder(), (char*)(m_data + m_size)) T(value);
+		++m_size;
 	}
 
-
-	template <class _Ty> struct remove_reference
-	{ // remove rvalue reference
-		typedef _Ty type;
-	};
-
-
-	template <class _Ty> struct remove_reference<_Ty&>
-	{ // remove rvalue reference
-		typedef _Ty type;
-	};
-
-	template <class _Ty> struct remove_reference<_Ty&&>
-	{ // remove rvalue reference
-		typedef _Ty type;
-	};
-
-	template <class _Ty> inline _Ty&& myforward(typename remove_reference<_Ty>::type& _Arg)
+	void push(T&& value)
 	{
-		return (static_cast<_Ty&&>(_Arg));
+		ensureCapacity();
+		new (NewPlaceholder(), (char*)(m_data + m_size)) T(mymove(value));
+		++m_size;
 	}
 
 	template <typename... Params> T& emplace(Params&&... params)
 	{
-		if (m_size == m_capacity)
-		{
-			grow();
-		}
+		ensureCapacity();
 		new (NewPlaceholder(), (char*)(m_data + m_size)) T(myforward<Params>(params)...);
 		++m_size;
 		return m_data[m_size - 1];
@@ -226,16 +218,13 @@ public:
 
 	template <typename... Params> T& emplaceAt(int idx, Params&&... params)
 	{
-		if (m_size == m_capacity)
+		if (idx == m_size)
 		{
-			grow();
+			return emplace(myforward<Params>(params)...);
 		}
-		for (int i = m_size - 1; i >= idx; --i)
-		{
-			copyMemory(&m_data[i + 1], &m_data[i], sizeof(m_data[i]));
-		}
-		new (NewPlaceholder(), (char*)(m_data + idx)) T(myforward<Params>(params)...);
-		++m_size;
+		makePlaceAt(idx);
+		T tmp(myforward<Params>(params)...);
+		m_data[idx] = mymove(tmp);
 		return m_data[idx];
 	}
 
@@ -272,64 +261,18 @@ public:
 		{
 			new (NewPlaceholder(), (char*)(m_data + i)) T();
 		}
-		callDestructors(m_data + size, m_data + m_size);
+		if (size < m_size)
+		{
+			callDestructors(m_data + size, m_data + m_size);
+		}
 		m_size = size;
-	}
-
-	void moveMemory(void* dest, const void* src, size_t count)
-	{
-		if(dest == src) return;
-
-		if(dest < src || dest >= (uint8*)src + count)
-		{
-			uint8* dest8 = (uint8*)dest;
-			const uint8* src8 = (const uint8*)src;
-
-			const uint8* src_end = src8 + count;
-			while(src8 != src_end)
-			{
-				*dest8 = *src8;
-				++src8;
-				++dest8;
-			}
-		}
-		else
-		{
-			uint8* dest8 = (uint8*)dest + count - 1;
-			const uint8* src8 = (const uint8*)src + count - 1;
-
-			while(src8 >= src)
-			{
-				*dest8 = *src8;
-				--src8;
-				--dest8;
-			}
-		}
-	}
-
-	void copyMemory(void* dest, const void* src, size_t count)
-	{
-		uint8* dest8 = (uint8*)dest;
-		const uint8* src8 = (const uint8*)src;
-
-		const uint8* src_end = src8 + count;
-		while(src8 != src_end)
-		{
-			*dest8 = *src8;
-			++src8;
-			++dest8;
-		}
 	}
 
 	void reserve(int capacity)
 	{
 		if (capacity > m_capacity)
 		{
-			T* newData = (T*)m_allocator.allocate(capacity * sizeof(T));
-			copyMemory(newData, m_data, sizeof(T) * m_size);
-			m_allocator.deallocate(m_data);
-			m_data = newData;
-			m_capacity = capacity;
+			growTo(capacity);
 		}
 	}
 
@@ -350,11 +293,47 @@ private:
 	void grow()
 	{
 		int newCapacity = m_capacity == 0 ? 4 : m_capacity * 2;
-		T* new_data = (T*)m_allocator.allocate(newCapacity * sizeof(T));
-		copyMemory(new_data, m_data, sizeof(T) * m_size);
-		m_allocator.deallocate(m_data);
-		m_data = new_data;
+		growTo(newCapacity);
+	}
+
+	void growFromEmpty(int newCapacity)
+	{
+		ASSERT(m_size == 0);
+		ASSERT(m_capacity == 0);
+		ASSERT(m_data == nullptr);
+		m_data = (T*)m_allocator.allocate(newCapacity * sizeof(T));
 		m_capacity = newCapacity;
+	}
+
+	void growTo(int newCapacity)
+	{
+		Array temp(m_allocator);
+		temp.growFromEmpty(newCapacity);
+		for (int i = 0; i < m_size; ++i)
+		{
+			temp.push(mymove(m_data[i]));
+		}
+		swap(temp);
+	}
+
+	void makePlaceAt(int idx)
+	{
+		ASSERT(idx >= 0 && idx < m_size);
+		ensureCapacity();
+		new (NewPlaceholder(), (char *)(m_data + m_size)) T(mymove(m_data[m_size-1]));
+		for (int i = m_size - 1; i - 1 >= idx; --i)
+		{
+			m_data[i] = mymove(m_data[i - 1]);
+		}
+		++m_size;
+	}
+
+	void ensureCapacity()
+	{
+		if (m_size == m_capacity)
+		{
+			grow();
+		}
 	}
 
 	void callDestructors(T* begin, T* end)

--- a/src/engine/core/type_traits.h
+++ b/src/engine/core/type_traits.h
@@ -1,0 +1,39 @@
+#pragma once
+
+namespace Lumix
+{
+
+template <bool, class T = void> struct myenable_if {};
+template <class T> struct myenable_if<true, T> {using type = T;};
+
+template <bool B, class T> using myenable_if_t = typename myenable_if<B, T>::type;
+
+template <class T> struct remove_reference
+{ // remove rvalue reference
+    typedef T type;
+};
+
+
+template <class T> struct remove_reference<T&>
+{ // remove rvalue reference
+    typedef T type;
+};
+
+template <class T> struct remove_reference<T&&>
+{ // remove rvalue reference
+    typedef T type;
+};
+
+template <class T> using remove_reference_t = typename remove_reference<T>::type;
+
+template <class T> inline T&& myforward(remove_reference_t<T>& _Arg)
+{
+    return (static_cast<T&&>(_Arg));
+}
+
+template <class T> inline remove_reference_t<T>&& mymove(T&& t)
+{
+    return static_cast<remove_reference_t<T>&&>(t);
+}
+
+} // ~namespace Lumix

--- a/src/engine/core/type_traits.h
+++ b/src/engine/core/type_traits.h
@@ -3,37 +3,32 @@
 namespace Lumix
 {
 
-template <bool, class T = void> struct myenable_if {};
-template <class T> struct myenable_if<true, T> {using type = T;};
-
-template <bool B, class T> using myenable_if_t = typename myenable_if<B, T>::type;
-
-template <class T> struct remove_reference
+template <class T> struct RemoveReference
 { // remove rvalue reference
     typedef T type;
 };
 
 
-template <class T> struct remove_reference<T&>
+template <class T> struct RemoveReference<T&>
 { // remove rvalue reference
     typedef T type;
 };
 
-template <class T> struct remove_reference<T&&>
+template <class T> struct RemoveReference<T&&>
 { // remove rvalue reference
     typedef T type;
 };
 
-template <class T> using remove_reference_t = typename remove_reference<T>::type;
+template <class T> using RemoveReferenceT = typename RemoveReference<T>::type;
 
-template <class T> inline T&& myforward(remove_reference_t<T>& _Arg)
+template <class T> inline T&& myforward(RemoveReferenceT<T>& t)
 {
-    return (static_cast<T&&>(_Arg));
+    return (static_cast<T&&>(t));
 }
 
-template <class T> inline remove_reference_t<T>&& mymove(T&& t)
+template <class T> inline RemoveReferenceT<T>&& mymove(T&& t)
 {
-    return static_cast<remove_reference_t<T>&&>(t);
+    return static_cast<RemoveReferenceT<T>&&>(t);
 }
 
 } // ~namespace Lumix

--- a/src/unit_tests/core/ut_array.cpp
+++ b/src/unit_tests/core/ut_array.cpp
@@ -83,5 +83,70 @@ void UT_array_erase(const char* params)
 	LUMIX_EXPECT(array1.size() == 15);
 }
 
+void UT_array_move(const char* params)
+{
+	Lumix::DefaultAllocator allocator;
+	Lumix::Array<int> array1(allocator);
+
+	for (int i = 0; i < 20; ++i)
+	{
+		array1.push(i * 5);
+	}
+
+	Lumix::Array<int> array2 = Lumix::mymove(array1);
+	LUMIX_EXPECT(array1.size() == 0);
+	LUMIX_EXPECT(array1.capacity() == 0);
+	LUMIX_EXPECT(array2.size() == 20);
+}
+
+namespace
+{
+class HasBackref
+{
+public:
+	HasBackref()
+		: m_backref(this)
+	{
+	}
+
+	~HasBackref()
+	{
+		m_backref = nullptr;
+	}
+
+	HasBackref(const HasBackref& rhs)
+		: m_backref(this)
+	{
+	}
+
+	void operator=(const HasBackref& rhs)
+	{
+	}
+
+	const HasBackref* backref() const { return m_backref; }
+
+private:
+	HasBackref* m_backref;
+};
+}
+
+void UT_array_safeInsert(const char* params)
+{
+	Lumix::DefaultAllocator allocator;
+	Lumix::Array<HasBackref> array(allocator);
+	for (int i = 0; i < 10; ++i) {
+		array.push(HasBackref());
+	}
+	for (int i = 0; i < 10; ++i) {
+		LUMIX_EXPECT(&array[i] == array[i].backref());
+	}
+	array.insert(5, HasBackref());
+	for (int i = 0; i < 10; ++i) {
+		LUMIX_EXPECT(&array[i] == array[i].backref());
+	}
+}
+
 REGISTER_TEST("unit_tests/core/array", UT_array, "")
 REGISTER_TEST("unit_tests/core/array/erase", UT_array_erase, "")
+REGISTER_TEST("unit_tests/core/array/move", UT_array_move, "")
+REGISTER_TEST("unit_tests/core/array/safeInsert", UT_array_safeInsert, "")


### PR DESCRIPTION
Athough first motivation for changes was remove `moveMemory` and `copyMemory` (since they work only on PODs), I couldn't resist to simplify things here and there.