### PR TITLE
Prevent assert on deserialization of zero sized arrays.

### DIFF
--- a/src/editor/prefab_system.cpp
+++ b/src/editor/prefab_system.cpp
@@ -478,7 +478,8 @@ public:
 		int count;
 		serializer.read(count);
 		m_prefabs.resize(count);
-		serializer.read(&m_prefabs[0], m_prefabs.size() * sizeof(m_prefabs[0]));
+		if (count > 0)
+			serializer.read(&m_prefabs[0], m_prefabs.size() * sizeof(m_prefabs[0]));
 		serializer.read(count);
 		for (int i = 0; i < count; ++i)
 		{

--- a/src/engine/universe/universe.cpp
+++ b/src/engine/universe/universe.cpp
@@ -346,7 +346,8 @@ void Universe::deserialize(InputBlob& serializer)
 	m_entities.resize(count);
 	for (auto& i : m_entities) i.components = 0;
 
-	serializer.read(&m_entities[0], sizeof(m_entities[0]) * m_entities.size());
+	if (count > 0)
+		serializer.read(&m_entities[0], sizeof(m_entities[0]) * m_entities.size());
 
 	serializer.read(count);
 	m_id_to_name_map.clear();


### PR DESCRIPTION
This was stopping at least the 'player' sample universe from returning to editor mode from game mode in debug builds. Perhaps this was intended though and the zero size array should not be happening in the first place?