### PR TITLE
Lock mouse position when rotating in ModelPlugin

### DIFF
--- a/src/renderer/editor/plugins.cpp
+++ b/src/renderer/editor/plugins.cpp
@@ -360,6 +360,7 @@ struct ModelPlugin LUMIX_FINAL : public AssetBrowser::IPlugin
 		m_mesh = INVALID_COMPONENT;
 		m_pipeline = nullptr;
 		m_universe = nullptr;
+		m_is_mouse_captured = false;
 
 		createPreviewUniverse();
 	}
@@ -435,6 +436,7 @@ struct ModelPlugin LUMIX_FINAL : public AssetBrowser::IPlugin
 			m_is_mouse_captured = false;
 			SDL_ShowCursor(1);
 			SDL_SetRelativeMouseMode(SDL_FALSE);
+			SDL_WarpMouseInWindow(nullptr, m_captured_mouse_x, m_captured_mouse_y);
 		}
 		
 		if (ImGui::IsItemHovered() && mouse_down)
@@ -446,9 +448,9 @@ struct ModelPlugin LUMIX_FINAL : public AssetBrowser::IPlugin
 			{
 				m_is_mouse_captured = true;
 				SDL_ShowCursor(0);
+				SDL_SetRelativeMouseMode(SDL_TRUE);
+				SDL_GetMouseState(&m_captured_mouse_x, &m_captured_mouse_y);
 			}
-
-			SDL_SetRelativeMouseMode(SDL_TRUE);
 
 			if (delta.x != 0 || delta.y != 0)
 			{
@@ -593,6 +595,8 @@ struct ModelPlugin LUMIX_FINAL : public AssetBrowser::IPlugin
 	Entity m_camera_entity;
 	ComponentHandle m_camera_cmp;
 	bool m_is_mouse_captured;
+	int m_captured_mouse_x;
+	int m_captured_mouse_y;
 };
 
 

--- a/src/renderer/material.cpp
+++ b/src/renderer/material.cpp
@@ -206,9 +206,10 @@ bool Material::save(JsonSerializer& serializer)
 	serializer.beginArray("defines");
 	for (int i = 0; i < sizeof(m_define_mask) * 8; ++i)
 	{
+		if ((m_define_mask & (1 << i)) == 0) continue;
 		const char* def = renderer.getShaderDefine(i);
 		if (equalStrings("SKINNED", def)) continue;
-		if (m_define_mask & (1 << i)) serializer.serializeArrayItem(def);
+		serializer.serializeArrayItem(def);
 	}
 	serializer.endArray();
 


### PR DESCRIPTION
Locking mouse while rotating is very nice 💛 

Doesn't actually lock the mouse, instead it captures the position and restores it when mouse capture ends. (Same as scene view)