### PR TITLE
Fix debugDrawNavmesh trying to render null tiles

### DIFF
--- a/src/navigation/navigation_system.cpp
+++ b/src/navigation/navigation_system.cpp
@@ -848,6 +848,8 @@ struct NavigationSceneImpl LUMIX_FINAL : public NavigationScene
 
 	void debugDrawNavmesh(const Vec3& pos, bool inner_boundaries, bool outer_boundaries, bool portals) override
 	{
+		if (pos.x > m_aabb.max.x || pos.x < m_aabb.min.x || pos.z > m_aabb.max.z || pos.z < m_aabb.min.z) return;
+
 		int x = int((pos.x - m_aabb.min.x + (1 + m_config.borderSize) * m_config.cs) / (CELLS_PER_TILE_SIDE * CELL_SIZE));
 		int z = int((pos.z - m_aabb.min.z + (1 + m_config.borderSize) * m_config.cs) / (CELLS_PER_TILE_SIDE * CELL_SIZE));
 		const dtMeshTile* tile = m_navmesh->getTileAt(x, z, 0);


### PR DESCRIPTION
If the scene camera raycast fails when navigation debug is enabled the navmesh at the camera's position is rendered. If the camera is outside the navmesh the editor crashes :(

The fix is to check that the requested position is inside the AABB of the navmesh before trying to render the tile (defensive-style). Not sure if it's better to fix it in the as I did here or to put it into the calling code (e.g. check if the raycast actually hits something).