### PR TITLE
Fixed Material and Shader reload bugs.

### DIFF
--- a/src/renderer/material.cpp
+++ b/src/renderer/material.cpp
@@ -150,6 +150,8 @@ void Material::unload(void)
 	}
 	m_texture_count = 0;
 	m_define_mask = 0;
+	m_render_layer = 0;
+	m_render_layer_mask = 1;
 }
 
 
@@ -800,7 +802,7 @@ bool Material::load(FS::IFile& file)
 		{
 			char tmp[32];
 			auto& renderer = static_cast<MaterialManager&>(m_resource_manager).getRenderer();
-			serializer.deserialize(tmp, lengthOf(tmp), "Default");
+			serializer.deserialize(tmp, lengthOf(tmp), "default");
 			m_render_layer = renderer.getLayer(tmp);
 			m_render_layer_mask = 1ULL << (u64)m_render_layer;
 		}

--- a/src/renderer/shader.cpp
+++ b/src/renderer/shader.cpp
@@ -433,6 +433,8 @@ void Shader::unload(void)
 	m_texture_slot_count = 0;
 
 	m_instances.clear();
+
+	m_all_defines_mask = 0;
 }
 
 


### PR DESCRIPTION
Some things aren't reset to default values when resources are unloaded.  These are the only ones that affected me, I'm sure there are others (Material.m_color etc).