### PR TITLE
Fixes to animation editor.

### DIFF
--- a/src/animation/editor/state_machine_editor.cpp
+++ b/src/animation/editor/state_machine_editor.cpp
@@ -1159,6 +1159,21 @@ void StateMachine::removeEntry(EntryEdge& entry)
 }
 
 
+void StateMachine::removeChild(Component* component)
+{
+	Container::removeChild(component);
+	auto* sm = (Anim::StateMachine*)engine_cmp;
+	for (int i = 0; i < m_entry_node->entries.size(); ++i)
+	{
+		auto entry = m_entry_node->entries[i];
+		if (entry->getTo()->engine_cmp == component->engine_cmp)
+		{
+			LUMIX_DELETE(m_allocator, entry);
+			break;
+		}
+	}
+}
+
 void StateMachine::onGUI()
 {
 	Container::onGUI();

--- a/src/animation/editor/state_machine_editor.h
+++ b/src/animation/editor/state_machine_editor.h
@@ -229,6 +229,7 @@ public:
 	void deserialize(InputBlob& blob) override;
 	void serialize(OutputBlob& blob) override;
 	EntryNode* getEntryNode() const { return m_entry_node; }
+	void removeChild(Component* component) override;
 	void compile() override;
 	void removeEntry(EntryEdge& entry);
 	void dropSlot(const char* name, u32 slot, const ImVec2& canvas_screen_pos) override;


### PR DESCRIPTION
animation_system.cpp: fixes a use-after-free bug when the .act file being edited is saved after playing it.

animation_editor.cpp: clear the undo stack when creating/loading a new .act, and when exiting

state_machine_editor.cpp/.h: ensure EntryEdges are removed when deleting a node