### PR TITLE
Fixed updateAnimables() for when all_count < job_count

### DIFF
--- a/src/animation/animation_system.cpp
+++ b/src/animation/animation_system.cpp
@@ -975,11 +975,13 @@ struct AnimationSceneImpl LUMIX_FINAL : public AnimationScene
 
 	void updateAnimables(float time_delta)
 	{
+		if (m_animables.size() == 0) return;
+
 		MTJD::Manager& mtjd = m_engine.getMTJDManager();
 		IAllocator& allocator = m_engine.getAllocator();
 		MTJD::Job* jobs[16];
 
-		int job_count = Math::minimum((int)mtjd.getCpuThreadsCount(), lengthOf(jobs));
+		int job_count = Math::minimum((int)mtjd.getCpuThreadsCount(), lengthOf(jobs), m_animables.size());
 		ASSERT(job_count > 0);
 		for (int i = 0; i < job_count; ++i)
 		{
@@ -989,7 +991,7 @@ struct AnimationSceneImpl LUMIX_FINAL : public AnimationScene
 				PROFILE_BLOCK("Animate Job");
 				int all_count = m_animables.size();
 				int batch_count = all_count / job_count;
-				if (i == job_count - 1) batch_count += all_count - 1 - (job_count * batch_count);
+				if (i == job_count - 1) batch_count = all_count - ((job_count - 1) * batch_count);
 				for (int j = 0; j < batch_count; ++j)
 				{
 					Animable& animable = m_animables.at(j + i * all_count / job_count);


### PR DESCRIPTION
This fixes the case where all_count = 1 and job_count = 7 for example, in which case:
 batch_count = all_count / job_count = 1 / 7 = 0.