### PR TITLE
Fix Screenshot upside down

### DIFF
--- a/src/renderer/texture.cpp
+++ b/src/renderer/texture.cpp
@@ -205,6 +205,7 @@ bool Texture::saveTGA(FS::IFile* file,
 	header.height = (short)height;
 	header.width = (short)width;
 	header.dataType = 2;
+	header.imageDescriptor = 32;
 
 	file->write(&header, sizeof(header));
 


### PR DESCRIPTION
TGA saving incorrectly because missing ImageDescriptor value.

Would you like to know more?