### PR TITLE
Small editor changes

### DIFF
--- a/src/editor/studio_app.cpp
+++ b/src/editor/studio_app.cpp
@@ -1253,6 +1253,8 @@ public:
 				m_editor->beginCommandGroup(crc32("create_child_entity"));
 				Entity child = m_editor->addEntity();
 				m_editor->makeParent(entity, child);
+                Vec3 pos = { 0, 0, 0 };
+                m_editor->setEntitiesLocalPositions(&child, &pos, 1);
 				m_editor->endCommandGroup();
 			}
 			ImGui::EndPopup();

--- a/src/editor/studio_app.cpp
+++ b/src/editor/studio_app.cpp
@@ -809,6 +809,7 @@ public:
 	void redo() { m_editor->redo(); }
 	void copy() { m_editor->copyEntities(); }
 	void paste() { m_editor->pasteEntities(); }
+    void duplicate() { m_editor->duplicateEntities(); }
 	bool isOrbitCamera() { return m_editor->isOrbitCamera(); }
 	void toggleOrbitCamera() { m_editor->setOrbitCamera(!m_editor->isOrbitCamera()); }
 	void setTopView() { m_editor->setTopView(); }
@@ -1045,6 +1046,7 @@ public:
 		ImGui::Separator();
 		doMenuItem(*getAction("copy"), is_any_entity_selected);
 		doMenuItem(*getAction("paste"), m_editor->canPasteEntities());
+        doMenuItem(*getAction("duplicate"), is_any_entity_selected);
 		ImGui::Separator();
 		doMenuItem(*getAction("orbitCamera"), is_any_entity_selected || m_editor->isOrbitCamera());
 		doMenuItem(*getAction("setTranslateGizmoMode"), true);
@@ -1464,6 +1466,7 @@ public:
 		addAction<&StudioAppImpl::undo>("Undo", "Undo scene action", "undo", SDLK_LCTRL, 'Z', -1);
 		addAction<&StudioAppImpl::copy>("Copy", "Copy entity", "copy", SDLK_LCTRL, 'C', -1);
 		addAction<&StudioAppImpl::paste>("Paste", "Paste entity", "paste", SDLK_LCTRL, 'V', -1);
+        addAction<&StudioAppImpl::duplicate>("Duplicate", "Duplicate entity", "duplicate", SDLK_LCTRL, 'D', -1);
 		addAction<&StudioAppImpl::toggleOrbitCamera>("Orbit camera", "Orbit camera", "orbitCamera")
 			.is_selected.bind<StudioAppImpl, &StudioAppImpl::isOrbitCamera>(this);
 		addAction<&StudioAppImpl::setTranslateGizmoMode>("Translate", "Set translate mode", "setTranslateGizmoMode")

--- a/src/editor/studio_app.cpp
+++ b/src/editor/studio_app.cpp
@@ -809,7 +809,7 @@ public:
 	void redo() { m_editor->redo(); }
 	void copy() { m_editor->copyEntities(); }
 	void paste() { m_editor->pasteEntities(); }
-    void duplicate() { m_editor->duplicateEntities(); }
+	void duplicate() { m_editor->duplicateEntities(); }
 	bool isOrbitCamera() { return m_editor->isOrbitCamera(); }
 	void toggleOrbitCamera() { m_editor->setOrbitCamera(!m_editor->isOrbitCamera()); }
 	void setTopView() { m_editor->setTopView(); }
@@ -1046,7 +1046,7 @@ public:
 		ImGui::Separator();
 		doMenuItem(*getAction("copy"), is_any_entity_selected);
 		doMenuItem(*getAction("paste"), m_editor->canPasteEntities());
-        doMenuItem(*getAction("duplicate"), is_any_entity_selected);
+		doMenuItem(*getAction("duplicate"), is_any_entity_selected);
 		ImGui::Separator();
 		doMenuItem(*getAction("orbitCamera"), is_any_entity_selected || m_editor->isOrbitCamera());
 		doMenuItem(*getAction("setTranslateGizmoMode"), true);
@@ -1255,8 +1255,8 @@ public:
 				m_editor->beginCommandGroup(crc32("create_child_entity"));
 				Entity child = m_editor->addEntity();
 				m_editor->makeParent(entity, child);
-                Vec3 pos = { 0, 0, 0 };
-                m_editor->setEntitiesLocalPositions(&child, &pos, 1);
+				Vec3 pos = { 0, 0, 0 };
+				m_editor->setEntitiesLocalPositions(&child, &pos, 1);
 				m_editor->endCommandGroup();
 			}
 			ImGui::EndPopup();
@@ -1466,7 +1466,7 @@ public:
 		addAction<&StudioAppImpl::undo>("Undo", "Undo scene action", "undo", SDLK_LCTRL, 'Z', -1);
 		addAction<&StudioAppImpl::copy>("Copy", "Copy entity", "copy", SDLK_LCTRL, 'C', -1);
 		addAction<&StudioAppImpl::paste>("Paste", "Paste entity", "paste", SDLK_LCTRL, 'V', -1);
-        addAction<&StudioAppImpl::duplicate>("Duplicate", "Duplicate entity", "duplicate", SDLK_LCTRL, 'D', -1);
+		addAction<&StudioAppImpl::duplicate>("Duplicate", "Duplicate entity", "duplicate", SDLK_LCTRL, 'D', -1);
 		addAction<&StudioAppImpl::toggleOrbitCamera>("Orbit camera", "Orbit camera", "orbitCamera")
 			.is_selected.bind<StudioAppImpl, &StudioAppImpl::isOrbitCamera>(this);
 		addAction<&StudioAppImpl::setTranslateGizmoMode>("Translate", "Set translate mode", "setTranslateGizmoMode")

--- a/src/editor/studio_app.cpp
+++ b/src/editor/studio_app.cpp
@@ -1256,7 +1256,7 @@ public:
 				Entity child = m_editor->addEntity();
 				m_editor->makeParent(entity, child);
 				Vec3 pos = { 0, 0, 0 };
-				m_editor->setEntitiesLocalPositions(&child, &pos, 1);
+				m_editor->setEntitiesPositions(&child, &pos, 1, true);
 				m_editor->endCommandGroup();
 			}
 			ImGui::EndPopup();

--- a/src/editor/world_editor.cpp
+++ b/src/editor/world_editor.cpp
@@ -175,7 +175,7 @@ public:
 		: m_blob(editor.getAllocator())
 		, m_editor(editor)
 		, m_entities(editor.getAllocator())
-        , m_identity(false)
+		, m_identity(false)
 	{
 	}
 
@@ -185,7 +185,7 @@ public:
 		, m_editor(editor)
 		, m_position(editor.getCameraRaycastHit())
 		, m_entities(editor.getAllocator())
-        , m_identity(identity)
+		, m_identity(identity)
 	{
 	}
 
@@ -195,7 +195,7 @@ public:
 		, m_editor(editor)
 		, m_position(pos)
 		, m_entities(editor.getAllocator())
-        , m_identity(identity)
+		, m_identity(identity)
 	{
 	}
 
@@ -208,7 +208,7 @@ public:
 		serializer.serialize("pos_x", m_position.x);
 		serializer.serialize("pos_y", m_position.y);
 		serializer.serialize("pos_z", m_position.z);
-        serializer.serialize("identity", m_identity);
+		serializer.serialize("identity", m_identity);
 		serializer.serialize("size", m_blob.getPos());
 		serializer.beginArray("data");
 		for (int i = 0; i < m_blob.getPos(); ++i)
@@ -224,7 +224,7 @@ public:
 		serializer.deserialize("pos_x", m_position.x, 0);
 		serializer.deserialize("pos_y", m_position.y, 0);
 		serializer.deserialize("pos_z", m_position.z, 0);
-        serializer.deserialize("identity", m_identity, false);
+		serializer.deserialize("identity", m_identity, false);
 		int size;
 		serializer.deserialize("size", size, 0);
 		serializer.deserializeArrayBegin("data");
@@ -261,7 +261,7 @@ private:
 	WorldEditor& m_editor;
 	Vec3 m_position;
 	Array<Entity> m_entities;
-    bool m_identity;
+	bool m_identity;
 };
 
 
@@ -275,7 +275,7 @@ public:
 		, m_old_rotations(editor.getAllocator())
 		, m_entities(editor.getAllocator())
 		, m_editor(editor)
-        , m_local(false)
+		, m_local(false)
 	{
 	}
 
@@ -286,14 +286,14 @@ public:
 		const Quat* new_rotations,
 		int count,
 		IAllocator& allocator,
-        bool local=false)
+		bool local=false)
 		: m_new_positions(allocator)
 		, m_new_rotations(allocator)
 		, m_old_positions(allocator)
 		, m_old_rotations(allocator)
 		, m_entities(allocator)
 		, m_editor(editor)
-        , m_local(local)
+		, m_local(local)
 	{
 		ASSERT(count > 0);
 		Universe* universe = m_editor.getUniverse();
@@ -338,7 +338,7 @@ public:
 
 	void serialize(JsonSerializer& serializer) override
 	{
-        serializer.serialize("local", m_local);
+		serializer.serialize("local", m_local);
 		serializer.serialize("count", m_entities.size());
 		serializer.beginArray("entities");
 		for (int i = 0; i < m_entities.size(); ++i)
@@ -360,7 +360,7 @@ public:
 	{
 		Universe* universe = m_editor.getUniverse();
 		int count;
-        serializer.deserialize("local", m_local, false);
+		serializer.deserialize("local", m_local, false);
 		serializer.deserialize("count", count, 0);
 		m_entities.resize(count);
 		m_new_positions.resize(count);
@@ -391,14 +391,14 @@ public:
 		for (int i = 0, c = m_entities.size(); i < c; ++i)
 		{
 			Entity entity = m_entities[i];
-            if (m_local)
-            {
-                universe->setLocalPosition(entity, m_new_positions[i]);
-            }
-            else
-            {
-                universe->setPosition(entity, m_new_positions[i]);
-            }
+			if (m_local)
+			{
+				universe->setLocalPosition(entity, m_new_positions[i]);
+			}
+			else
+			{
+				universe->setPosition(entity, m_new_positions[i]);
+			}
 
 			universe->setRotation(entity, m_new_rotations[i]);
 		}
@@ -412,14 +412,14 @@ public:
 		for (int i = 0, c = m_entities.size(); i < c; ++i)
 		{
 			Entity entity = m_entities[i];
-            if (m_local)
-            {
-                universe->setLocalPosition(entity, m_old_positions[i]);
-            }
-            else
-            {
-                universe->setPosition(entity, m_old_positions[i]);
-            }
+			if (m_local)
+			{
+				universe->setLocalPosition(entity, m_old_positions[i]);
+			}
+			else
+			{
+				universe->setPosition(entity, m_old_positions[i]);
+			}
 
 			universe->setRotation(entity, m_old_rotations[i]);
 		}
@@ -462,7 +462,7 @@ private:
 	Array<Quat> m_new_rotations;
 	Array<Vec3> m_old_positions;
 	Array<Quat> m_old_rotations;
-    bool m_local;
+	bool m_local;
 };
 
 
@@ -2779,20 +2779,20 @@ public:
 		executeCommand(command);
 	}
 
-    void setEntitiesLocalPositions(const Entity* entities, const Vec3* positions, int count) override
-    {
-        ASSERT(entities && positions);
-        if (count <= 0) return;
+	void setEntitiesLocalPositions(const Entity* entities, const Vec3* positions, int count) override
+	{
+		ASSERT(entities && positions);
+		if (count <= 0) return;
 
-        Universe* universe = getUniverse();
-        Array<Quat> rots(m_allocator);
-        for (int i = 0; i < count; ++i) {
-            rots.push(universe->getRotation(entities[i]));
-        }
-        IEditorCommand* command =
-            LUMIX_NEW(m_allocator, MoveEntityCommand)(*this, entities, positions, &rots[0], count, m_allocator, true);
-        executeCommand(command);
-    }
+		Universe* universe = getUniverse();
+		Array<Quat> rots(m_allocator);
+		for (int i = 0; i < count; ++i) {
+			rots.push(universe->getRotation(entities[i]));
+		}
+		IEditorCommand* command =
+			LUMIX_NEW(m_allocator, MoveEntityCommand)(*this, entities, positions, &rots[0], count, m_allocator, true);
+		executeCommand(command);
+	}
 
 
 	void setEntitiesPositionsAndRotations(const Entity* entities,
@@ -3025,13 +3025,13 @@ public:
 		executeCommand(command);
 	}
 
-    void duplicateEntities() override
-    {
-        copyEntities();
+	void duplicateEntities() override
+	{
+		copyEntities();
 
-        PasteEntityCommand* command = LUMIX_NEW(m_allocator, PasteEntityCommand)(*this, m_copy_buffer, true);
-        executeCommand(command);
-    }
+		PasteEntityCommand* command = LUMIX_NEW(m_allocator, PasteEntityCommand)(*this, m_copy_buffer, true);
+		executeCommand(command);
+	}
 
 
 	void cloneComponent(const ComponentUID& src, Entity entity) override
@@ -3972,21 +3972,21 @@ bool PasteEntityCommand::execute()
 		Entity parent;
 		blob.read(parent);
 
-        if (!m_identity)
-        {
-            if (i == 0)
-            {
-                Matrix inv = mtx;
-                inv.inverse();
-                base_matrix.copy3x3(mtx);
-                base_matrix = base_matrix * inv;
-                mtx.setTranslation(m_position);
-            }
-            else
-            {
-                mtx = base_matrix * mtx;
-            }
-        }
+		if (!m_identity)
+		{
+			if (i == 0)
+			{
+				Matrix inv = mtx;
+				inv.inverse();
+				base_matrix.copy3x3(mtx);
+				base_matrix = base_matrix * inv;
+				mtx.setTranslation(m_position);
+			}
+			else
+			{
+				mtx = base_matrix * mtx;
+			}
+		}
 
 		Entity new_entity;
 		if (is_redo)

--- a/src/editor/world_editor.cpp
+++ b/src/editor/world_editor.cpp
@@ -2127,7 +2127,7 @@ public:
 		auto& fs = m_engine->getFileSystem();
 		StaticString<MAX_PATH_LENGTH> dir(m_engine->getDiskFileDevice()->getBasePath(), "universes");
 		PlatformInterface::makePath(dir);
-		StaticString<MAX_PATH_LENGTH> path("universes/", basename, ".unv");
+		StaticString<MAX_PATH_LENGTH> path(dir, basename, ".unv");
 		FS::IFile* file = fs.open(fs.getDefaultDevice(), Path(path), FS::Mode::CREATE_AND_WRITE);
 		save(*file);
 		fs.close(*file);

--- a/src/editor/world_editor.cpp
+++ b/src/editor/world_editor.cpp
@@ -2763,7 +2763,7 @@ public:
 	}
 
 
-	void setEntitiesPositions(const Entity* entities, const Vec3* positions, int count) override
+	void setEntitiesPositions(const Entity* entities, const Vec3* positions, int count, bool local=false) override
 	{
 		ASSERT(entities && positions);
 		if (count <= 0) return;
@@ -2775,34 +2775,19 @@ public:
 			rots.push(universe->getRotation(entities[i]));
 		}
 		IEditorCommand* command =
-			LUMIX_NEW(m_allocator, MoveEntityCommand)(*this, entities, positions, &rots[0], count, m_allocator);
+			LUMIX_NEW(m_allocator, MoveEntityCommand)(*this, entities, positions, &rots[0], count, m_allocator, local);
 		executeCommand(command);
 	}
-
-	void setEntitiesLocalPositions(const Entity* entities, const Vec3* positions, int count) override
-	{
-		ASSERT(entities && positions);
-		if (count <= 0) return;
-
-		Universe* universe = getUniverse();
-		Array<Quat> rots(m_allocator);
-		for (int i = 0; i < count; ++i) {
-			rots.push(universe->getRotation(entities[i]));
-		}
-		IEditorCommand* command =
-			LUMIX_NEW(m_allocator, MoveEntityCommand)(*this, entities, positions, &rots[0], count, m_allocator, true);
-		executeCommand(command);
-	}
-
 
 	void setEntitiesPositionsAndRotations(const Entity* entities,
 		const Vec3* positions,
 		const Quat* rotations,
-		int count) override
+		int count,
+		bool local=false) override
 	{
 		if (count <= 0) return;
 		IEditorCommand* command =
-			LUMIX_NEW(m_allocator, MoveEntityCommand)(*this, entities, positions, rotations, count, m_allocator);
+			LUMIX_NEW(m_allocator, MoveEntityCommand)(*this, entities, positions, rotations, count, m_allocator, local);
 		executeCommand(command);
 	}
 

--- a/src/editor/world_editor.h
+++ b/src/editor/world_editor.h
@@ -115,6 +115,7 @@ public:
 	virtual void selectEntities(const Entity* entities, int count) = 0;
 	virtual Entity addEntityAt(int camera_x, int camera_y) = 0;
 	virtual void setEntitiesPositions(const Entity* entities, const Vec3* positions, int count) = 0;
+    virtual void setEntitiesLocalPositions(const Entity* entities, const Vec3* positions, int count) = 0;
 	virtual void setEntitiesCoordinate(const Entity* entities, int count, float value, Coordinate coord) = 0;
 	virtual void setEntitiesLocalCoordinate(const Entity* entities, int count, float value, Coordinate coord) = 0;
 	virtual void setEntitiesScale(const Entity* entities, int count, float scale) = 0;

--- a/src/editor/world_editor.h
+++ b/src/editor/world_editor.h
@@ -124,7 +124,8 @@ public:
 	virtual void setEntitiesPositionsAndRotations(const Entity* entity,
 		const Vec3* position,
 		const Quat* rotation,
-		int count, bool local=false) = 0;
+		int count, 
+		bool local=false) = 0;
 	virtual void setEntityName(Entity entity, const char* name) = 0;
 	virtual void snapDown() = 0;
 	virtual void toggleGameMode() = 0;

--- a/src/editor/world_editor.h
+++ b/src/editor/world_editor.h
@@ -115,8 +115,7 @@ public:
 	virtual void destroyEntities(const Entity* entities, int count) = 0;
 	virtual void selectEntities(const Entity* entities, int count) = 0;
 	virtual Entity addEntityAt(int camera_x, int camera_y) = 0;
-	virtual void setEntitiesPositions(const Entity* entities, const Vec3* positions, int count) = 0;
-    virtual void setEntitiesLocalPositions(const Entity* entities, const Vec3* positions, int count) = 0;
+	virtual void setEntitiesPositions(const Entity* entities, const Vec3* positions, int count, bool local=false) = 0;
 	virtual void setEntitiesCoordinate(const Entity* entities, int count, float value, Coordinate coord) = 0;
 	virtual void setEntitiesLocalCoordinate(const Entity* entities, int count, float value, Coordinate coord) = 0;
 	virtual void setEntitiesScale(const Entity* entities, int count, float scale) = 0;
@@ -125,7 +124,7 @@ public:
 	virtual void setEntitiesPositionsAndRotations(const Entity* entity,
 		const Vec3* position,
 		const Quat* rotation,
-		int count) = 0;
+		int count, bool local=false) = 0;
 	virtual void setEntityName(Entity entity, const char* name) = 0;
 	virtual void snapDown() = 0;
 	virtual void toggleGameMode() = 0;

--- a/src/editor/world_editor.h
+++ b/src/editor/world_editor.h
@@ -104,6 +104,7 @@ public:
 	virtual void copyEntities() = 0;
 	virtual bool canPasteEntities() const = 0;
 	virtual void pasteEntities() = 0;
+    virtual void duplicateEntities() = 0;
 	virtual void addComponent(ComponentType type) = 0;
 	virtual void cloneComponent(const ComponentUID& src, Entity entity) = 0;
 	virtual void destroyComponent(const Entity* entities, int count, ComponentType cmp_type) = 0;


### PR DESCRIPTION
Hi there,

I've recently found this and I must say I love the engine so far!

I would like to present some adjustments I made to make entity manipulation slightly better.
Editor is now able to duplicate entities and keep their original transformation based on the original version, created child of an entity should now also be located at (0,0,0) local position now.
There's also small possible bug fix when saving the universe would crash the editor. It could be because I have a slightly different workspace layout, but the fix should deal with such exceptions.

I will also create PR for that particular icon I made for "Duplicate entity" option [here](https://github.com/nem0/lumixengine_data/pull/109).

Thank you!
- Dominik.