### PR TITLE
Fix Dynamic Build

### DIFF
--- a/projects/genie.lua
+++ b/projects/genie.lua
@@ -848,7 +848,7 @@ if build_app then
 		if build_studio then
 			linkLib "crnlib"
 			linkLib "cmft"
-			links {"shaderc"}
+			links { "renderer", "shaderc" }
 		end
 		
 		linkLib "bgfx"


### PR DESCRIPTION
Linked renderer back into dynamic app build if studio included as you cannot use studio without renderer anyway.

Let me know if this is okay or just dumb :)