### PR TITLE
Fix truncated clipboard text

### DIFF
--- a/src/engine/win/os.cpp
+++ b/src/engine/win/os.cpp
@@ -1030,7 +1030,7 @@ bool getOpenDirectory(Span<char> output, const char* starting_dir)
 void copyToClipboard(const char* text)
 {
 	if (!OpenClipboard(NULL)) return;
-	int len = stringLength(text);
+	int len = stringLength(text) + 1;
 	HGLOBAL mem_handle = GlobalAlloc(GMEM_MOVEABLE, len * sizeof(char));
 	if (!mem_handle) return;
 


### PR DESCRIPTION
Clipboard text memory size did not account for the null terminator.

I noticed this when I had a string with no newline at the end miss one character.
