### PR TITLE
fixes for old universes, reflection names, physics scene clear

### DIFF
--- a/src/editor/prefab_system.cpp
+++ b/src/editor/prefab_system.cpp
@@ -661,7 +661,13 @@ public:
 		for (u32 i = 0; i < count; ++i) {
 			const EntityPtr e = entity_map.get(EntityPtr{(i32)i});
 			PrefabHandle prefab;
-			serializer.read(prefab);
+			if ((u32)version <= (u32)UniverseSerializedVersion::HASH64) {
+				u32 dummy;
+				serializer.read(dummy);
+			}
+			else {
+				serializer.read(prefab);
+			}
 
 			if (!e.isValid()) continue;
 			while (e.index >= m_entity_to_prefab.size()) {

--- a/src/engine/reflection.h
+++ b/src/engine/reflection.h
@@ -280,7 +280,7 @@ inline Icon icon(const char* name) { return {name}; }
 
 namespace detail {
 
-static const unsigned int FRONT_SIZE = sizeof("Lumix::detail::GetTypeNameHelper<") - 1u;
+static const unsigned int FRONT_SIZE = sizeof("Lumix::reflection::detail::GetTypeNameHelper<") - 1u;
 static const unsigned int BACK_SIZE = sizeof(">::GetTypeName") - 1u;
 
 template <typename T>

--- a/src/physics/physics_scene.cpp
+++ b/src/physics/physics_scene.cpp
@@ -4106,8 +4106,20 @@ void PhysicsSceneImpl::RigidActor::setMesh(PhysicsGeometry* new_value)
 				scene.m_resource_actor_map[mesh] = *next_with_mesh;
 			}
 
-			if (next_with_mesh.isValid()) scene.m_actors[*next_with_mesh].prev_with_mesh = prev_with_mesh;
-			if (prev_with_mesh.isValid()) scene.m_actors[*prev_with_mesh].next_with_mesh = next_with_mesh;
+			if (next_with_mesh.isValid()) {
+				auto actor = scene.m_actors.find(*next_with_mesh);
+				if (actor.isValid()) {
+					actor.value().prev_with_mesh = prev_with_mesh;
+				}
+			}
+			if (prev_with_mesh.isValid()) 
+			{
+				auto actor = scene.m_actors.find(*prev_with_mesh);
+				if (actor.isValid()) {
+					actor.value().next_with_mesh = next_with_mesh;
+				}
+				else ASSERT(0);
+			}
 		}
 	}
 	mesh = new_value;


### PR DESCRIPTION
Hello nem0, some easy fixes plus when destroying the universe and the physic scene is cleared, this happens:
m_actors.clear() -> ~RigidActor() -> setMesh(nullptr)
here some actors in m_actors can be already be dead, so better do a find to check.